### PR TITLE
Produce docs for events

### DIFF
--- a/winmd2markdown/Format.cpp
+++ b/winmd2markdown/Format.cpp
@@ -95,7 +95,12 @@ string Formatter::ResolveReferences(string sane, Converter converter) {
             ss << (this->*converter)(ns, typeName, suffix);
           }
           else {
-            throw exception(("unknown reference: " + reference).c_str());
+            if (program->opts->strictReferences) {
+              throw exception(("unknown reference: " + reference).c_str());
+            }
+            else {
+              ss << reference << " (unresolved reference)";
+            }
           }
         }
       }
@@ -165,7 +170,7 @@ string Formatter::ToString(const coded_index<TypeDefOrRef>& tdr, bool toCode) {
       for (auto const& a : s.GenericArgs())
       {
         auto x = GetType(a);
-        return x;
+        return p + "<" + x + ">";
       }
 
       return "TypeSpec";

--- a/winmd2markdown/Options.cpp
+++ b/winmd2markdown/Options.cpp
@@ -15,6 +15,7 @@ const std::vector<option>  get_option_names() {
     { "fileSuffix", "File suffix to append to each generated markdown file. Default is \"-api-windows\"", STRING_SWITCH_SETTER(fileSuffix) },
     { "outputDirectory", "Directory where output will be written. Default is \"out\"", STRING_SWITCH_SETTER(outputDirectory) },
     { "printReferenceGraph", "Displays the list of types that reference each type", BOOL_SWITCH_SETTER(printReferenceGraph )},
+    { "strictReferences", "Produce an error when failing to resolve a reference", BOOL_SWITCH_SETTER(strictReferences)},
   };
   return option_names;
 }

--- a/winmd2markdown/Options.h
+++ b/winmd2markdown/Options.h
@@ -25,7 +25,7 @@ struct options
   std::string outputDirectory{ "out" };
   bool printReferenceGraph{ false };
   std::string apiVersion;
-
+  bool strictReferences{ false };
 
   options(const std::vector<std::string>& v) {
     auto const opts = get_option_names();

--- a/winmd2markdown/output.h
+++ b/winmd2markdown/output.h
@@ -12,7 +12,8 @@ enum class MemberType
   Property,
   Type,
   Field,
-  Method
+  Method,
+  Event
 };
 
 struct intellisense_xml
@@ -56,6 +57,8 @@ private:
       return 'T';
     case MemberType::Method:
       return 'M';
+    case MemberType::Event:
+      return 'E';
     default:
       throw std::invalid_argument("unexpected member type");
     }


### PR DESCRIPTION
This requires us reaching over to the type's `add_XYZ` method since that's where attributes get applied, not to the event.