### PR TITLE
Resolve references in descriptions and fix Formatter::ToString

### DIFF
--- a/winmd2markdown/Format.cpp
+++ b/winmd2markdown/Format.cpp
@@ -165,15 +165,24 @@ string Formatter::ToString(const coded_index<TypeDefOrRef>& tdr, bool toCode) {
       const auto& ts = tdr.TypeSpec();
       const auto& n = ts.Signature();
       const auto& s = n.GenericTypeInst();
-      const auto& p = ToString(s.GenericType());
+      const auto& p = s.GenericType();
       const auto& ac = s.GenericArgCount();
+      const auto& outerType = std::string(ToString(p, false));
+      const auto& prettyOuterType = outerType.substr(1, outerType.find('`') - 1);
+      string result = typeToMarkdown(p.TypeRef().TypeNamespace(), prettyOuterType, true, "-" + std::to_string(ac)) + "<";
+
+      bool first = true;
       for (auto const& a : s.GenericArgs())
       {
+        if (!first) {
+          result += ", ";
+        }
         auto x = GetType(a);
-        return p + "<" + x + ">";
+        result += x;
+        first = false;
       }
-
-      return "TypeSpec";
+      result += ">";
+      return result;
     }
     default:
       throw std::invalid_argument("");

--- a/winmd2markdown/Program.cpp
+++ b/winmd2markdown/Program.cpp
@@ -465,6 +465,7 @@ void Program::process_property(output& ss, const Property& prop) {
   auto cppAttrs = (isStatic ? (code("static") + "   ") : "") + (readonly ? (code("readonly") + " ") : "");
   if (opts->propertiesAsTable) {
     auto description = GetDocString(prop);
+    description = format.ResolveReferences(description, &Formatter::MakeMarkdownReference);
     if (!default_val.empty()) {
       description += "<br/>default: " + default_val;
     }
@@ -535,7 +536,7 @@ void Program::process_field(output& ss, const Field& field) {
   const auto& type = format.GetType(field.Signature().Type());
   const auto& name = string(field.Name());
   if (opts->fieldsAsTable) {
-    auto description = GetDocString(field);
+    auto description = format.ResolveReferences(GetDocString(field), &Formatter::MakeMarkdownReference);
     ss << "| " << name << " | " << type << " | " << description << " |\n";
   }
   else {
@@ -641,7 +642,7 @@ void Program::process_enum(output& ss, const TypeDef& type) {
     const auto elementType = value.Signature().Type().element_type();
     const auto val = getVariantValueAs<int64_t>(value.Constant().Value());
 
-    ss << "|" << code(value.Name()) << " | " << std::hex << "0x" << val << "  |  " << GetDocString(value) << "|\n";
+    ss << "|" << code(value.Name()) << " | " << std::hex << "0x" << val << "  |  " << format.ResolveReferences(GetDocString(value), &Formatter::MakeMarkdownReference) << "|\n";
   }
 }
 


### PR DESCRIPTION
A couple style fixes:

### Resolves references in descriptions in table

### Fixes ToString for TypeDefOrRef::TypeSpec

- Fix GenericType name (trim `2 suffix)
- Fix GenericType URL (`2 should be -2 instead)
- Add missing GenericArgs

IDL:
```idl
event Windows.Foundation.TypedEventHandler<CoreWebView2, CoreWebView2ClientCertificateRequestedEventArgs> ClientCertificateRequested;
```

Before:
```md
Type: [`TypedEventHandler`2`](https://docs.microsoft.com/uwp/api/Windows.Foundation.TypedEventHandler`2)<[`CoreWebView2`](CoreWebView2)>
```

After:
```md
Type: [`TypedEventHandler`](/uwp/api/Windows.Foundation.TypedEventHandler-2)<[`CoreWebView2`](corewebview2), [CoreWebView2ClientCertificateRequestedEventArgs](corewebview2clientcertificaterequestedeventargs)>
```
