### PR TITLE
Fix operation being the first paramName for async methods

### DIFF
--- a/winmd2markdown/Program.cpp
+++ b/winmd2markdown/Program.cpp
@@ -508,7 +508,8 @@ void Program::process_method(output& ss, const MethodDef& method, string_view re
     paramNames.push_back(p.Name());
   }
   constexpr auto resultParamName = "result";
-  if (!paramNames.empty() && paramNames[0] == resultParamName) {
+  constexpr auto operationParamName = "operation";
+  if (!paramNames.empty() && (paramNames[0] == resultParamName || paramNames[0] == operationParamName)) {
     paramNames.erase(paramNames.begin());
   }
 

--- a/winmd2markdown/Program.cpp
+++ b/winmd2markdown/Program.cpp
@@ -507,9 +507,7 @@ void Program::process_method(output& ss, const MethodDef& method, string_view re
   for (auto const& p : method.ParamList()) {
     paramNames.push_back(p.Name());
   }
-  constexpr auto resultParamName = "result";
-  constexpr auto operationParamName = "operation";
-  if (!paramNames.empty() && (paramNames[0] == resultParamName || paramNames[0] == operationParamName)) {
+  if (!paramNames.empty() && realName.empty() && returnType != "void") {
     paramNames.erase(paramNames.begin());
   }
 


### PR DESCRIPTION
### Fixes `operation` being the first paramName for async methods

Note that before the change, the param names are [**operation**, browserExecutableFolder, userDataFolder] instead of [browserExecutableFolder, userDataFolder, options].

IDL:
```idl
static Windows.Foundation.IAsyncOperation<CoreWebView2Environment> CreateWithOptionsAsync(String browserExecutableFolder, String userDataFolder, CoreWebView2EnvironmentOptions options);
```

Before:
```md
> static [`IAsyncOperation`](/uwp/api/Windows.Foundation.IAsyncOperation-1)&lt;[CoreWebView2Environment](corewebview2environment.md)&gt; CreateWithOptionsAsync(string operation, string browserExecutableFolder, [CoreWebView2EnvironmentOptions](corewebview2environmentoptions.md) userDataFolder)
```

After:
```md
> static [`IAsyncOperation`](/uwp/api/Windows.Foundation.IAsyncOperation-1)&lt;[CoreWebView2Environment](corewebview2environment.md)&gt; CreateWithOptionsAsync(string browserExecutableFolder, string userDataFolder, [CoreWebView2EnvironmentOptions](corewebview2environmentoptions.md) options)
```
